### PR TITLE
Add `scheduler` parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$PYTHON
   - source activate test-environment
-  - conda install dask numpy scikit-learn=$SKLEARN cytoolz pytest
+  - conda install dask distributed numpy scikit-learn=$SKLEARN cytoolz pytest
   - pip install -q graphviz flake8
   - pip install --no-deps -e .
 

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -580,7 +580,10 @@ def test_normalize_n_jobs():
 @pytest.mark.parametrize('scheduler,n_jobs,get',
                          [(None, 4, get_threading),
                           ('threading', 4, get_threading),
+                          ('threaded', 4, get_threading),
                           ('threading', 1, dask.get),
+                          ('sequential', 4, dask.get),
+                          ('synchronous', 4, dask.get),
                           ('sync', 4, dask.get),
                           ('multiprocessing', 4, None),
                           (dask.get, 4, dask.get)])

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -578,7 +578,7 @@ def test_scheduler_param(scheduler):
 
 
 @pytest.mark.skipif('loop is None')
-def test_scheduler_param_distriuted(loop):
+def test_scheduler_param_distributed(loop):
     X, y = make_classification(n_samples=100, n_features=10, random_state=0)
     gs = dcv.GridSearchCV(MockClassifier(), {'foo_param': [0, 1, 2]}, cv=3)
     with cluster() as (s, [a, b]):

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -112,11 +112,12 @@ def test_grid_search_no_score():
     # wrong results. This only happens with threads, not processes/sync.
     # For now, we'll fit using the sync scheduler.
     grid_search = dcv.GridSearchCV(clf, {'C': Cs}, scoring='accuracy',
-                                   get=dask.get)
+                                   scheduler='sync')
     grid_search.fit(X, y)
 
     grid_search_no_score = dcv.GridSearchCV(clf_no_score, {'C': Cs},
-                                            scoring='accuracy', get=dask.get)
+                                            scoring='accuracy',
+                                            scheduler='sync')
     # smoketest grid search
     grid_search_no_score.fit(X, y)
 
@@ -782,7 +783,7 @@ def test_grid_search_correct_score_results():
         # in wrong results. This only happens with threads, not processes/sync.
         # For now, we'll fit using the sync scheduler.
         grid_search = dcv.GridSearchCV(clf, {'C': Cs}, scoring=score,
-                                       cv=n_splits, get=dask.get)
+                                       cv=n_splits, scheduler='sync')
         cv_results = grid_search.fit(X, y).cv_results_
 
         # Test scorer names

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -4,7 +4,6 @@
 
 import pickle
 import pytest
-from distutils.version import LooseVersion
 
 import dask
 import dask.array as da
@@ -14,7 +13,6 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 import scipy.sparse as sp
 from scipy.stats import expon
 
-import sklearn
 from sklearn.base import BaseEstimator
 from sklearn.cluster import KMeans
 from sklearn.datasets import (make_classification, make_blobs,
@@ -811,8 +809,6 @@ def test_grid_search_correct_score_results():
                 assert_almost_equal(correct_score, cv_scores[i])
 
 
-@pytest.mark.skipif(LooseVersion(sklearn.__version__) < '0.18.1',
-                    reason="Pickle of masked-arrays broken in 0.18.0")
 def test_pickle():
     # Test that a fit search can be pickled
     clf = MockClassifier()


### PR DESCRIPTION
Allow specifying the scheduler by name instead of passing in the `get` function directly. Scheduler can be one of:
- None, to use the global scheduler, falls back to threading if not set (default)
- A string specifying the scheduler name ("threading", "multiprocessing", or "sync")
- A scheduler get function
- Anything that can be passed to `dask.distributed.Client`.

---

Not fully set on this yet.

Pros:
- Easier for less dask-savy users to specify different schedulers, feels a bit more like joblib.

Cons:
- Doesn't match how schedulers are normally set in dask. Disconnect may feel foreign.

If we go this route, then I'd also add `n_jobs` as a parameter (matching scikit-learn), which would specify `num_workers` for the threading and multiprocessing schedulers, and be ignored by the others. Might also make `n_jobs=1` for all but distributed result in the synchronous scheduler. Downside of supporting `n_jobs` here is we'd probably want the default to match what dask does (`n_jobs = cpu_count()`) instead of what scikit-learn does (`n_jobs=1`). I'm fine with this, but it is a difference.

If we don't go this route, then I might add a `scheduler_kwargs` parameter instead, which would be forwarded to the `get` call. Not sure if any of the other keyword arguments would prove useful for this library though.