### PR TITLE
Online fit - WIP

### DIFF
--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -41,9 +41,11 @@ from .methods import (fit, fit_transform, fit_and_score, pipeline, fit_best,
 from .utils import to_indexable, to_keys, unzip
 
 try:
-    from cytoolz import get, pluck
+    from cytoolz import get, pluck, concat
 except:  # pragma: no cover
-    from toolz import get, pluck
+    from toolz import get, pluck, concat
+
+import dask_searchcv.online_model_selection as oms
 
 
 __all__ = ['GridSearchCV', 'RandomizedSearchCV']
@@ -83,9 +85,16 @@ def build_graph(estimator, cv, scorer, candidate_params, X, y=None,
         fit_params = {}
 
     fields, tokens, params = normalize_params(candidate_params)
-    main_token = tokenize(normalize_estimator(estimator), fields, params,
-                          X_name, y_name, groups_name, fit_params, cv,
-                          error_score == 'raise', return_train_score)
+    main_token = tokenize(normalize_estimator(estimator),  # main token doesn't depend on params
+                          X_name,
+                          y_name,
+                          groups_name,
+                          fit_params,
+                          cv,
+                          error_score == 'raise',
+                          return_train_score)
+
+    param_token = tokenize(fields, params)
 
     cv_name = 'cv-split-' + main_token
     dsk[cv_name] = (cv_split, cv, X_name, y_name, groups_name,
@@ -98,21 +107,21 @@ def build_graph(estimator, cv, scorer, candidate_params, X, y=None,
         weights = None
 
     scores = do_fit_and_score(dsk, main_token, estimator, cv_name, fields,
-                              tokens, params, X_name, y_name, fit_params,
+                              tokens, param_token, params, X_name, y_name, fit_params,
                               n_splits, error_score, scorer,
                               return_train_score)
 
-    cv_results = 'cv-results-' + main_token
-    candidate_params_name = 'cv-parameters-' + main_token
+    cv_results = 'cv-results-' + main_token + '-' + param_token
+    candidate_params_name = 'cv-parameters-' + main_token + '-' + param_token
     dsk[candidate_params_name] = (decompress_params, fields, params)
     dsk[cv_results] = (create_cv_results, scores, candidate_params_name,
                        n_splits, error_score, weights)
     keys = [cv_results]
 
     if refit:
-        best_params = 'best-params-' + main_token
+        best_params = 'best-params-' + main_token + '-' + param_token
         dsk[best_params] = (get_best_params, candidate_params_name, cv_results)
-        best_estimator = 'best-estimator-' + main_token
+        best_estimator = 'best-estimator-' + main_token + '-' + param_token
         if fit_params:
             fit_params = (dict, (zip, list(fit_params.keys()),
                                 list(pluck(1, fit_params.values()))))
@@ -159,7 +168,7 @@ def _group_fit_params(steps, fit_params):
     return param_lk
 
 
-def do_fit_and_score(dsk, main_token, est, cv, fields, tokens, params,
+def do_fit_and_score(dsk, main_token, est, cv, fields, tokens, param_token, params,
                      X, y, fit_params, n_splits, error_score, scorer,
                      return_train_score):
     if not isinstance(est, Pipeline):
@@ -168,11 +177,12 @@ def do_fit_and_score(dsk, main_token, est, cv, fields, tokens, params,
 
         est_type = type(est).__name__.lower()
         est_name = '%s-%s' % (est_type, main_token)
-        score_name = '%s-fit-score-%s' % (est_type, main_token)
+        score_name = '%s-fit-score-%s-%s' % (est_type, main_token, param_token)
         dsk[est_name] = est
 
         seen = {}
         m = 0
+
         out = []
         out_append = out.append
 
@@ -195,14 +205,14 @@ def do_fit_and_score(dsk, main_token, est, cv, fields, tokens, params,
         y_train = (cv_extract, cv, X, y, False, True)
         y_test = (cv_extract, cv, X, y, False, False)
 
-        # Fit the estimator on the training data
+        # Fit the estimator on the training data  # todo: refactor for async seen
         X_trains = [X_train] * len(params)
         y_trains = [y_train] * len(params)
-        fit_ests = do_fit(dsk, TokenIterator(main_token), est, cv,
+        fit_ests = do_fit(dsk, TokenIterator(main_token+'-'+param_token), est, cv,
                           fields, tokens, params, X_trains, y_trains,
                           fit_params, n_splits, error_score)
 
-        score_name = 'score-' + main_token
+        score_name = 'score-' + main_token + '-' + param_token
 
         scores = []
         scores_append = scores.append
@@ -239,6 +249,8 @@ def do_fit(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
         est_type = type(est).__name__.lower()
         est_name = '%s-%s' % (est_type, token)
         fit_name = '%s-fit-%s' % (est_type, token)
+        # this doesn't depend on the params yet
+        # we need to create the key out of the accumulated names in the parameter/estimator tree
         dsk[est_name] = est
 
         seen = {}
@@ -278,7 +290,7 @@ def do_fit_transform(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
             fields = None
 
         name = type(est).__name__.lower()
-        token = next_token(est)
+        token = next_token(est)  # todo: involve the parameters in the name ...
         fit_Xt_name = '%s-fit-transform-%s' % (name, token)
         fit_name = '%s-fit-%s' % (name, token)
         Xt_name = '%s-transform-%s' % (name, token)
@@ -350,7 +362,7 @@ def _do_fit_step(dsk, next_token, step, cv, fields, tokens, params, Xs, ys,
         new_Xs = {}
         est_index = field_to_index[step_name]
 
-        for ids in _group_ids_by_index(est_index, tokens):
+        for ids in _group_ids_by_index(est_index, tokens):  # iterating over all param versions for this step
             # Get the estimator for this subgroup
             sub_est = params[ids[0]][est_index]
             if sub_est is MISSING:
@@ -421,6 +433,7 @@ def _do_fit_step(dsk, next_token, step, cv, fields, tokens, params, Xs, ys,
     return (fits, Xs) if is_transform else (fits, None)
 
 
+# this is the important one to append info to
 def _do_pipeline(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
                  fit_params, n_splits, error_score, is_transform):
     if 'steps' in fields:
@@ -434,6 +447,7 @@ def _do_pipeline(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
     instrs.append((est.steps[-1], is_transform))
 
     fit_steps = []
+    # we want to separate all of the parameters out - generating keys only for used parameters
     for (step_name, step), transform in instrs:
         fits, Xs = _do_fit_step(dsk, next_token, step, cv, fields, tokens,
                                 params, Xs, ys, fit_params, n_splits,
@@ -759,7 +773,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
                              % self.best_estimator_)
         return self.scorer_(self.best_estimator_, X, y)
 
-    def fit(self, X, y=None, groups=None, **fit_params):
+    def fit(self, X, y=None, groups=None, block=False, **fit_params):
         """Run fit with all sets of parameters.
 
         Parameters
@@ -784,27 +798,51 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
             raise ValueError("error_score must be the string 'raise' or a"
                              " numeric value.")
 
-        dsk, keys, n_splits = build_graph(estimator, self.cv, self.scorer_,
-                                          list(self._get_param_iterator()),
-                                          X, y, groups, fit_params,
-                                          iid=self.iid,
-                                          refit=self.refit,
-                                          error_score=error_score,
-                                          return_train_score=self.return_train_score,
-                                          cache_cv=self.cache_cv)
+        dsk, X_name, y_name, cv_name, n_splits = oms.build_graph(
+            estimator, X, y, self.cv, groups, self.cache_cv)
+
         self.dask_graph_ = dsk
         self.n_splits_ = n_splits
+
+        # populate the graph with jobs
+        keys, params_list = [], []
+        for params in self._get_param_iterator():
+            cv_score_names = oms.update_graph(dsk, estimator, X_name, y_name, params, fit_params,
+                                          cv_name, n_splits,
+                                          self.scorer_, self.return_train_score,
+                                          error_score=error_score)
+            keys.append(cv_score_names)
+            params_list.append(params)
 
         n_jobs = _normalize_n_jobs(self.n_jobs)
         scheduler = _normalize_scheduler(self.scheduler, n_jobs)
 
-        out = scheduler(dsk, keys, num_workers=n_jobs)
+        scores = scheduler(dsk, keys, num_workers=n_jobs)
+        scores = tuple(concat(zip(*scores)))  # fixme: ugly hack for the moment to compare
 
-        self.cv_results_ = results = out[0]
+        if self.iid:
+            weights_name = 'cv-n-samples-' + tokenize(
+                normalize_estimator(estimator), X_name, y_name, params, fit_params,
+                cv_name, n_splits)
+            oms.update_dsk(dsk, weights_name, (cv_n_samples, cv_name))
+            weights = scheduler(dsk, weights_name)
+        else:
+            weights = None
+
+        self.cv_results_ = results = create_cv_results(
+            scores, params_list, n_splits, error_score, weights=weights
+        )
+
         self.best_index_ = np.flatnonzero(results["rank_test_score"] == 1)[0]
 
         if self.refit:
-            self.best_estimator_ = out[1]
+            best_params = results['params'][self.best_index_]
+            # we do this locally (should be possible by key (from fit_name)):
+            token = tokenize(normalize_estimator(estimator), best_params, X_name, y_name, fit_params)
+            best_fit_key = 'best-fit-{}'.format(token)
+            dsk[best_fit_key] = (fit_best, clone(estimator), best_params, X_name, y_name, fit_params)
+            self.best_estimator_ = scheduler(dsk, best_fit_key)
+
         return self
 
     def visualize(self, filename='mydask', format=None, **kwargs):

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -12,6 +12,7 @@ from dask.base import tokenize, Base
 from dask.delayed import delayed
 from dask.threaded import get as threaded_get
 from dask.utils import derived_from
+from distributed import Client, as_completed
 from sklearn import model_selection
 from sklearn.base import is_classifier, clone, BaseEstimator, MetaEstimatorMixin
 from sklearn.exceptions import NotFittedError
@@ -1179,3 +1180,74 @@ class RandomizedSearchCV(DaskBaseSearchCV):
         """Return ParameterSampler instance for the given distributions"""
         return model_selection.ParameterSampler(self.param_distributions,
                 self.n_iter, random_state=self.random_state)
+
+
+class OnlineRandomizedSearchCV(DaskBaseSearchCV):
+    def __init__(self, estimator, param_distributions, n_iter=10,
+                 random_state=None, scoring=None, iid=True, refit=True,
+                 cv=None, error_score='raise', return_train_score=True,
+                 scheduler=None, n_jobs=-1, cache_cv=True):
+
+        super(OnlineRandomizedSearchCV, self).__init__(estimator=estimator,
+                scoring=scoring, iid=iid, refit=refit, cv=cv,
+                error_score=error_score, return_train_score=return_train_score,
+                scheduler=scheduler, n_jobs=n_jobs, cache_cv=cache_cv)
+
+        self.param_distributions = param_distributions
+        self.n_iter = n_iter
+        self.random_state = random_state
+
+    def _get_param_iterator(self):
+        """Return infinite number of parameters"""
+        return model_selection.ParameterSampler(self.param_distributions,
+                np.inf, random_state=self.random_state)
+
+    def fit(self, X, y=None, groups=None, client=None, target_score=0.95, **fit_params):
+        """Run fit with all sets of parameters, returns the running search, status can be checked
+        """
+
+        if client is None:
+            client = Client()
+
+        estimator = self.estimator
+        self.scorer_ = check_scoring(estimator, scoring=self.scoring)
+        error_score = self.error_score
+        if not (isinstance(error_score, numbers.Number) or
+                error_score == 'raise'):
+            raise ValueError("error_score must be the string 'raise' or a"
+                             " numeric value.")
+
+        dsk, X_name, y_name, cv_name, n_splits = oms.build_graph(
+            estimator, X, y, self.cv, groups, self.cache_cv)
+
+        self.dask_graph_ = dsk
+        self.n_splits_ = n_splits
+
+        ncores = client.ncores()
+
+        param_iter = self._get_param_iterator()
+        futures, param_list = [], []
+
+        for _ in range(ncores * 2):
+            params = next(param_iter)
+            score_name = oms.update_graph(dsk, estimator, X_name, y_name, params, fit_params,
+                                              cv_name, n_splits,
+                                              self.scorer_, self.return_train_score,
+                                              error_score=error_score)
+            futures.append(score_name)
+
+        best = -np.inf
+
+        for future in as_completed(futures):
+            score, params = future.result()
+            if score > best:
+                best = score
+                best_params = params
+
+            if best > target_score:
+                break
+
+            future = client.submit(try_and_score, next(param_iter))
+            futures.add(future)
+
+        return self

--- a/dask_searchcv/online_model_selection.py
+++ b/dask_searchcv/online_model_selection.py
@@ -1,0 +1,450 @@
+"""
+Online model selection
+
+Book-keeping is achieved by tokenization of args with an assertion to 
+avoid mutation of existing items with different values. I.e. this ensures that our 
+tokenize(func, args) works.
+
+"""
+
+
+import logging
+import numbers
+import operator as op
+from multiprocessing import cpu_count
+
+import dask
+import dask.array as da
+import toolz as tz
+from dask import delayed
+from dask.base import tokenize, Base
+from dask.delayed import Delayed
+from dask.threaded import get as threaded_get
+from dask_searchcv._normalize import normalize_estimator
+from dask_searchcv.methods import fit_transform, fit, score, cv_split, cv_extract, \
+    feature_union_concat, feature_union, pipeline
+from dask_searchcv.utils import to_keys, to_indexable
+from sklearn import model_selection
+from sklearn.base import is_classifier
+from sklearn.model_selection import LeaveOneGroupOut, LeavePGroupsOut, LeavePOut, LeaveOneOut
+from sklearn.model_selection._split import _CVIterableWrapper, PredefinedSplit, _BaseKFold, \
+    BaseShuffleSplit, StratifiedKFold, KFold
+from sklearn.pipeline import Pipeline, FeatureUnion
+from sklearn.utils.multiclass import type_of_target
+from sklearn.utils.validation import _num_samples
+
+log = logging.getLogger(__name__)
+
+
+def _to_keys(dsk, *args):
+    """Safe to_keys"""
+    for x in args:
+        if x is None:
+            yield None
+        elif isinstance(x, da.Array):
+            x = delayed(x)
+            dsk.update(x.dask)
+            yield x.key
+        elif isinstance(x, Delayed):
+            dsk.update(x.dask)
+            yield x.key
+        else:
+            assert not isinstance(x, Base)
+            key = 'array-' + tokenize(x)
+            dsk[key] = x
+            yield key
+
+
+def _persist_fit_params(dsk, fit_params):
+    """Persist all input fit params to the cv cache and return keys in place with full name 
+    """
+    if fit_params:
+        # A mapping of {name: (name, graph-key)}
+        param_values = to_indexable(*fit_params.values(), allow_scalars=True)
+        _fit_params = {k: (k, token) for (k, token) in zip(fit_params, _to_keys(dsk, *param_values))}
+    else:
+        _fit_params = {}
+    return _fit_params
+
+
+def _cv_extract_params(cvs, keys, full_names, tokens, n):
+    # key doesn't matter (even if it's been modified) only token
+    return {k: cvs.extract_param(name, token, n) for (k, name, token) in zip(keys, full_names, tokens)}
+
+
+def _fit_params_for_n(fit_params, cv_name, n):
+    return {k: (cv_name, n, full_name, token) for k, (full_name, token) in fit_params.items()}
+
+
+def _group_fit_params(steps, fit_params):
+    param_lk = {n: {} for n, _ in steps}
+    for pname, pval in fit_params.items():
+        step, param = pname.split('__', 1)
+        param_lk[step][param] = pval
+    return param_lk
+
+
+def _get_fit_params(fit_params):
+    """Reconstruct the parameters at time of submitting fit to graph"""
+    if fit_params:
+        assert len({(n, cv_name) for _, (cv_name, n, full_name, token) in fit_params.items()})
+        cv_name, n, _, _ = next(iter(fit_params.values()))
+        keys, full_names, tokens = (
+            list(fit_params.keys()),
+            list(tz.pluck(2, fit_params.values())),
+            list(tz.pluck(3, fit_params.values()))
+        )
+        return _cv_extract_params, cv_name, keys, full_names, tokens, n
+    else:
+        return {}
+
+
+def check_cv(cv=3, y=None, classifier=False):
+    """Dask aware version of ``sklearn.model_selection.check_cv``
+
+    Same as the scikit-learn version, but works if ``y`` is a dask object.
+    """
+    if cv is None:
+        cv = 3
+
+    # If ``cv`` is not an integer, the scikit-learn implementation doesn't
+    # touch the ``y`` object, so passing on a dask object is fine
+    if not isinstance(y, Base) or not isinstance(cv, numbers.Integral):
+        return model_selection.check_cv(cv, y, classifier)
+
+    if classifier:
+        # ``y`` is a dask object. We need to compute the target type
+        target_type = delayed(type_of_target, pure=True)(y).compute()
+        if target_type in ('binary', 'multiclass'):
+            return StratifiedKFold(cv)
+    return KFold(cv)
+
+
+def compute_n_splits(cv, X, y=None, groups=None):
+    """Return the number of splits.
+
+    Parameters
+    ----------
+    cv : BaseCrossValidator
+    X, y, groups : array_like, dask object, or None
+
+    Returns
+    -------
+    n_splits : int
+    """
+    if not any(isinstance(i, Base) for i in (X, y, groups)):
+        return cv.get_n_splits(X, y, groups)
+
+    if isinstance(cv, (_BaseKFold, BaseShuffleSplit)):
+        return cv.n_splits
+
+    elif isinstance(cv, PredefinedSplit):
+        return len(cv.unique_folds)
+
+    elif isinstance(cv, _CVIterableWrapper):
+        return len(cv.cv)
+
+    elif isinstance(cv, (LeaveOneOut, LeavePOut)) and not isinstance(X, Base):
+        # Only `X` is referenced for these classes
+        return cv.get_n_splits(X, None, None)
+
+    elif (isinstance(cv, (LeaveOneGroupOut, LeavePGroupsOut)) and not
+          isinstance(groups, Base)):
+        # Only `groups` is referenced for these classes
+        return cv.get_n_splits(None, None, groups)
+
+    else:
+        return delayed(cv).get_n_splits(X, y, groups).compute()
+
+
+def _normalize_n_jobs(n_jobs):
+    if not isinstance(n_jobs, int):
+        raise TypeError("n_jobs should be an int, got %s" % n_jobs)
+    if n_jobs == -1:
+        n_jobs = None  # Scheduler default is use all cores
+    elif n_jobs < -1:
+        n_jobs = cpu_count() + 1 + n_jobs
+    return n_jobs
+
+
+_scheduler_aliases = {'sync': 'synchronous',
+                      'sequential': 'synchronous',
+                      'threaded': 'threading'}
+
+
+def _normalize_scheduler(scheduler, n_jobs, loop=None):
+    # Default
+    if scheduler is None:
+        scheduler = dask.context._globals.get('get')
+        if scheduler is None:
+            scheduler = dask.get if n_jobs == 1 else threaded_get
+        return scheduler
+
+    # Get-functions
+    if callable(scheduler):
+        return scheduler
+
+    # Support name aliases
+    if isinstance(scheduler, str):
+        scheduler = _scheduler_aliases.get(scheduler, scheduler)
+
+    if scheduler in ('threading', 'multiprocessing') and n_jobs == 1:
+        scheduler = dask.get
+    elif scheduler == 'threading':
+        scheduler = threaded_get
+    elif scheduler == 'multiprocessing':
+        from dask.multiprocessing import get as scheduler
+    elif scheduler == 'synchronous':
+        scheduler = dask.get
+    else:
+        try:
+            from dask.distributed import Client
+            # We pass loop to make testing possible, not needed for normal use
+            return Client(scheduler, set_as_default=False, loop=loop).get
+        except Exception as e:
+            msg = ("Failed to initialize scheduler from parameter %r. "
+                   "This could be due to a typo, or a failure to initialize "
+                   "the distributed scheduler. Original error is below:\n\n"
+                   "%r" % (scheduler, e))
+        # Re-raise outside the except to provide a cleaner error message
+        raise ValueError(msg)
+    return scheduler
+
+
+def _str_cmp(x, y):
+    return str(x) == str(y)
+
+_exception_string = (
+        'graph already has a key {k} with a different value: old: {vold}, new: {vnew}'
+    )
+
+
+def update_dsk(dsk, k, v, cmp=_str_cmp):
+    if k in dsk:
+        if not cmp(dsk[k], v):
+            raise ValueError(
+                _exception_string.format(d=dsk, k=k, vold=dsk[k], vnew=v))
+    else:
+        dsk[k] = v
+
+
+def assoc_params_with_steps(params, steps):
+    plist = []
+    for step, _ in steps:
+        _params = {k: v for k, v in params.items() if k.split('__')[0] == step and k != step}
+        plist.append((step, {'__'.join(k.split('__')[1:]): v for k, v in _params.items()}))
+    return plist
+
+
+def flesh_out_params(estimator, params):
+    if any(k.endswith('transformer_list') for k in params.keys()):
+        raise(NotImplementedError("Setting FeatureUnion.transformer_list "
+                                  "in a DaskBaseSearchCV search"))
+    if any(k.endswith('steps') for k in params.keys()):
+        raise(NotImplementedError("Setting Pipeline.steps "
+                                  "in a DaskBaseSearchCV search"))
+
+    default_params = estimator.get_params()
+    # we dissoc the transformer lists, todo: do this for estimators as well
+    # default_params = {k: v for k, v in default_params.items() if not k.endswith('transformer_list')}
+
+    # note: there can be new parameters if they are
+    # get new default parameters implied by subestimators in a pipeline
+    # todo: sub_estimators = []
+    # if not all(k in default_params for k in params):
+    #     # log.warn('All parameters should be relevant to the estimator - pruning extras')
+    #     # params = {k: v for k, v in params.items() if k in default_params}
+    #     raise ValueError('All parameters should be relevant to the estimator')
+
+    return tz.merge(default_params, params)
+
+
+def check_estimator_parameters(est, params):
+    if not all(k in est.get_params() for k in params):
+        raise ValueError("We only accept parameters that are in est")
+
+
+def do_fit(dsk, est, X_name, y_name, params, fit_params, error_score):
+    check_estimator_parameters(est, params)
+
+    if isinstance(est, Pipeline):
+        return do_pipeline(
+            dsk, est, X_name, y_name, params, fit_params, error_score, transform=False)
+    elif isinstance(est, FeatureUnion):
+        return tz.first(do_featureunion(dsk, est, X_name, y_name, params, fit_params, error_score))
+    else:
+        est_type = type(est).__name__.lower()
+        est_name = est_type + '-' + tokenize(normalize_estimator(est))
+        update_dsk(dsk, est_name, est)
+        fit_name = '%s-fit-%s' % (est_type, tokenize(est_name, X_name, y_name, params, fit_params))
+
+        fit_params_ = _get_fit_params(fit_params)
+        update_dsk(dsk, fit_name, (
+            fit, est_name, X_name, y_name, error_score, list(params.keys()), list(params.values()),
+            fit_params_))
+        return fit_name
+
+
+def do_fit_transform(dsk, est, X_name, y_name, params, fit_params, error_score):
+    check_estimator_parameters(est, params)
+    if isinstance(est, Pipeline):
+        return do_pipeline(
+            dsk, est, X_name, y_name, params, fit_params, error_score, transform=True)
+    elif isinstance(est, FeatureUnion):
+        return do_featureunion(dsk, est, X_name, y_name, params, fit_params, error_score)
+    else:
+        est_type = type(est).__name__.lower()
+        est_name = None if est is None else est_type + '-' + tokenize(normalize_estimator(est))
+        update_dsk(dsk, est_name, est)
+
+        token = tokenize(est_name, X_name, y_name, params, fit_params)
+        fit_Xt_name = '%s-fit-transform-%s' % (est_type, token)
+        fit_name = '%s-fit-%s' % (est_type, token)
+        Xt_name = '%s-transform-%s' % (est_type, token)
+
+        fit_params_ = _get_fit_params(fit_params)
+        update_dsk(dsk, fit_Xt_name, (
+            fit_transform, est_name, X_name, y_name, error_score, list(params.keys()), list(params.values()),
+            fit_params_))
+        update_dsk(dsk, fit_name, (op.getitem, fit_Xt_name, 0))
+        update_dsk(dsk, Xt_name, (op.getitem, fit_Xt_name, 1))
+
+        return fit_name, Xt_name
+
+
+def do_pipeline(dsk, est, X_name, y_name, params, fit_params, error_score, transform=False):
+    check_estimator_parameters(est, params)
+
+    params_dict = dict(assoc_params_with_steps(params, est.steps))
+    fit_params_dict = _group_fit_params(est.steps, fit_params)
+    fit_steps = []
+    Xt_name = X_name
+    for step_name, step in est.steps[:-1]:
+        fit_params_ = _get_fit_params(fit_params_dict[step_name])
+        fit_name, Xt_name = do_fit_transform(
+            dsk, step, Xt_name, y_name,
+            params_dict[step_name], fit_params_, error_score
+        ) if step else (None, Xt_name)  # ... pass-through for pipeline
+        fit_steps.append(fit_name)
+    step_name, step = est.steps[-1]
+    # fit_params_ = _get_fit_params(fit_params_dict[step_name])
+
+    if transform:
+        fit_name, Xt_name = do_fit_transform(
+            dsk, step, Xt_name, y_name,
+            params_dict[step_name], fit_params_dict[step_name], error_score
+        ) if step else (None, Xt_name)
+    else:
+        fit_name = do_fit(
+            dsk, step, Xt_name, y_name,
+            params_dict[step_name], fit_params_dict[step_name], error_score
+        ) if step else None
+    fit_steps.append(fit_name)
+
+    est_type = type(est).__name__.lower()
+    # fit_params = _get_fit_params(fit_params)  # we keep the keys for tokenizing
+    token = tokenize(X_name, y_name, params, fit_params, error_score, transform)
+    fit_name = est_type + '-' + token
+    step_names = list(tz.pluck(0, est.steps))
+    update_dsk(dsk, fit_name, (pipeline, step_names, fit_steps))
+
+    return (fit_name, Xt_name) if transform else fit_name
+
+
+def do_featureunion(dsk, est, X_name, y_name, params, fit_params, error_score):
+    check_estimator_parameters(est, params)
+
+    est_type = type(est).__name__.lower()
+    est_name = est_type + '-' + tokenize(normalize_estimator(est))
+    update_dsk(dsk, est_name, est)
+
+    token = tokenize(est_name, X_name, params, fit_params, error_score)
+    n_samples_name = 'n_samples-' + token
+    update_dsk(dsk, n_samples_name, (_num_samples, X_name))
+
+    fit_steps = []
+    tr_Xs = []
+    params_dict = dict(assoc_params_with_steps(params, est.transformer_list))
+    fit_params_dict = _group_fit_params(est.transformer_list, fit_params)
+    for (step_name, step) in est.transformer_list:
+        params_ = params_dict[step_name]
+        fit_params_ = _get_fit_params(fit_params_dict[step_name])
+        if step is None:
+            fit_name, Xt = None, None
+        else:
+            fit_name, Xt = do_fit_transform(
+                dsk, step, X_name, y_name,
+                params_, fit_params_, error_score
+            )
+        fit_steps.append(fit_name)
+        tr_Xs.append(Xt)
+
+    w = params.get('transformer_weights', est.transformer_weights)
+    wdict = w or {}
+    weight_list = [wdict.get(n) for n, _ in est.transformer_list]
+
+    fit_name = est_type + '-' + token
+    tr_name = 'feature-union-concat-' + token
+    step_names, steps = zip(*est.transformer_list)
+    update_dsk(dsk, fit_name, (feature_union, step_names, fit_steps, wdict))
+    update_dsk(dsk, tr_name, (feature_union_concat, tr_Xs, n_samples_name, weight_list))
+
+    return fit_name, tr_name
+
+
+def do_score(dsk, fit_name, X_name, y_name, X_test_name, y_test_name, scorer, return_train_score):
+    score_name = 'score-' + tokenize(fit_name, X_test_name, y_test_name, scorer)
+    update_dsk(dsk, score_name, (
+        score, fit_name, X_test_name, y_test_name, X_name if return_train_score else None, y_name,
+        scorer
+    ))
+    return score_name
+
+
+def do_fit_and_score(
+    dsk, est, Xtrain_name, ytrain_name, Xtest_name, ytest_name, params, fit_params, scorer,
+    return_train_score, error_score
+):
+    # n_and_fit_params = _get_fit_params(cv, fit_params, n_splits)
+    fit_name = do_fit(dsk, est, Xtrain_name, ytrain_name, params, fit_params, error_score)
+    score_name = do_score(
+        dsk, fit_name, Xtrain_name, ytrain_name, Xtest_name, ytest_name, scorer, return_train_score)
+
+    return score_name
+
+
+def build_graph(estimator, X, y, cv, groups, cache_cv=True):
+    dsk = {}
+    X, y, groups = to_indexable(X, y, groups)
+    X_name, y_name, groups_name = to_keys(dsk, X, y, groups)
+    cv = check_cv(cv, y, is_classifier(estimator))
+    n_splits = compute_n_splits(cv, X, y, groups)
+    is_pairwise = getattr(estimator, '_pairwise', False)
+    # accumulating all keys that influence input data:
+    data_token = tokenize(cv, X_name, y_name, groups_name, is_pairwise)
+    # should we put cache_cv in the data_token, (does it have any effect on the computation graph)?
+    cv_name = 'cv-split-' + data_token
+    update_dsk(dsk, cv_name, (cv_split, cv, X_name, y_name, groups_name, is_pairwise, cache_cv))
+
+    return dsk, X_name, y_name, cv_name, n_splits
+
+
+def update_graph(dsk, estimator, X_name, y_name, params, fit_params, cv_name, n_splits, scorer,
+                 return_train_score, error_score):
+    # munge parameters, for unique keys:
+    params = flesh_out_params(estimator, params)
+    fit_params = _persist_fit_params(dsk, fit_params)  # todo: safe update of graph??
+
+    cv_score_names = []
+    for n in range(n_splits):
+        xtrain = (cv_extract, cv_name, X_name, y_name, True, True, n)
+        ytrain = (cv_extract, cv_name, X_name, y_name, False, True, n)
+        xtest = (cv_extract, cv_name, X_name, y_name, True, False, n)
+        ytest = (cv_extract, cv_name, X_name, y_name, False, False, n)
+        fit_params_n = _fit_params_for_n(fit_params, cv_name, n)
+
+        score_name = do_fit_and_score(dsk, estimator, xtrain, ytrain, xtest, ytest, params,
+                                      fit_params_n, scorer, return_train_score, error_score)
+        cv_score_names.append(score_name)
+
+    return cv_score_names

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -92,6 +92,8 @@ def test_hyperparameter_searcher_with_fit_params(cls, kwargs):
     assert "Expected fit parameter(s) ['eggs'] not seen." in str(exc.value)
 
     searcher.fit(X, y, clf__spam=np.ones(10), clf__eggs=np.zeros(10))
+
+    # todo: fix this test
     # Test with dask objects as parameters
     searcher.fit(X, y, clf__spam=da.ones(10, chunks=2),
                  clf__eggs=dask.delayed(np.zeros(10)))

--- a/dask_searchcv/tests/test_online_model_selection.py
+++ b/dask_searchcv/tests/test_online_model_selection.py
@@ -1,0 +1,166 @@
+import logging
+
+import numpy as np
+import pytest
+from dask.base import tokenize
+from sklearn.base import BaseEstimator
+from sklearn.pipeline import Pipeline
+
+from dask_searchcv._normalize import normalize_estimator
+from dask_searchcv.methods import feature_union_concat
+from dask_searchcv.model_selection import _normalize_scheduler
+from dask_searchcv.online_model_selection import do_fit, do_pipeline, \
+    do_fit_transform, flesh_out_params, update_dsk
+from dask_searchcv.utils import to_keys
+
+loglevel = pytest.config.getoption("--log", 'INFO')
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=getattr(logging, loglevel))
+
+
+def test_semi_mutable_mapping():
+    d = {}
+    update_dsk(d, 'a', 1)
+
+    with pytest.raises(ValueError) as exc_info:
+        update_dsk(d, 'a', 2)
+        assert str(exc_info) == d._exception_string.format(d=d, k='a', vold=d['a'], vnew=2)
+
+    update_dsk(d, 'b', 2)
+
+    assert set(d.items()) == {('b', 2), ('a', 1)}
+
+
+class Thing1(BaseEstimator):
+    def __init__(self, a=1, b=0):
+        self.a = a
+        self.b = b
+
+    def fit(self, X, y):
+        return self
+
+    def transform(self, X, y=None):
+        return X
+
+
+class Thing2(BaseEstimator):
+    def __init__(self, r=None, s=1):
+        self.r = r
+        self.s = s
+
+    def fit(self, X, y):
+        return self
+
+    def transform(self, X, y=None):
+        return X
+
+num_cmp_cols = [
+    'mean_test_score', 'mean_train_score', 'split0_test_score',
+    'split0_train_score', 'split1_test_score', 'split1_train_score',
+    'split2_test_score', 'split2_train_score', 'std_test_score',
+    'std_train_score'
+]
+
+
+def estimator_name(estimator):
+    return type(estimator).__name__.__lower__() + '-' + tokenize(normalize_estimator(estimator))
+
+
+def test_do_fit():
+    def check_val_and_graph(k1, k2, g1, g2):
+        assert (k1 == k2), "Keys don't match!"
+        assert (len(g1) == len(g2)), "Graphs don't match!"
+
+    dsk = {}
+
+    est = Thing1()
+    X, y = np.ones((2, 2), dtype=np.float64), np.ones(2, dtype=np.float64)
+    params = {}
+    params = flesh_out_params(est, params)
+    X_name, y_name = to_keys(dsk, X, y)
+
+    fit_name = do_fit(dsk, est, X_name, y_name, params, fit_params={}, error_score='raise')
+    g1 = dict(dsk).copy()
+
+    # a new estimator initialised with the same arguments should not change the graph:
+    est2 = Thing1()
+    fit_name2 = do_fit(dsk, est2, X_name, y_name, params, fit_params={}, error_score='raise')
+    g2 = dict(dsk).copy()
+
+    check_val_and_graph(fit_name, fit_name2, g1, g2)
+
+    # a new fit with parameters that are the same as the estimator parameters should not change the
+    # graph:
+    params_same_as_default = {'a': 1, 'b': 0}
+    fit_name3 = do_fit(dsk, est2, X_name, y_name, params_same_as_default, fit_params={},
+                       error_score='raise')
+    g3 = dict(dsk).copy()
+
+    check_val_and_graph(fit_name, fit_name3, g1, g3)
+
+    # note: if parameters are wrong type (float vs int) a new key is constructed:
+    params_same_as_default = {'a': 1., 'b': 0.}
+    fit_name4 = do_fit(dsk, est2, X_name, y_name, params_same_as_default, fit_params={},
+                       error_score='raise')
+    g4 = dict(dsk).copy()
+
+    with pytest.raises(AssertionError) as exc_info:
+        check_val_and_graph(fit_name, fit_name4, g1, g4)
+
+
+def test_do_fit_transform():
+    dsk = {}
+    est = Thing1()
+    X, y = np.ones((2, 2), dtype=np.float64), np.ones(2, dtype=np.float64)
+    params = {}
+    params = flesh_out_params(est, params)
+    X_name, y_name = to_keys(dsk, X, y)
+    fit_name, Xt_name = do_fit_transform(dsk, est, X_name, y_name, params, fit_params={}, error_score='raise')
+
+    assert any('-fit-' in k for k in dsk)
+    assert any('-fit-transform-' in k for k in dsk)
+    assert len(dsk) == 6
+    assert Xt_name.startswith('thing1-transform-')
+
+
+def test_do_pipeline():
+    pipeline = Pipeline([
+        ('step1', Thing1(b=2)),
+        ('step2', Thing2(r=1.4))
+    ])
+
+    dsk = {}
+    X, y = np.ones((2, 2), dtype=np.float64), np.ones(2, dtype=np.float64)
+
+    params = {
+        'step1__a': 1,
+        'step2__r': 2.5,
+    }
+
+    params = flesh_out_params(pipeline, params)
+    X_name, y_name = to_keys(dsk, X, y)
+    fit_name = do_pipeline(dsk, pipeline, X_name, y_name, params, fit_params={},
+                           error_score='raise')
+    assert isinstance(dsk, dict)
+    log.info(fit_name)
+    assert fit_name.startswith('pipeline-')
+
+    with pytest.raises(ValueError) as exc_info:
+        fit_name, Xt_name = do_pipeline(dsk, pipeline, X_name, y_name, params, fit_params={},
+                                        error_score='raise', transform=True)
+        log.info("We don't support changing the structure of the graph so pipeline fit->transform")
+        log.info(str(exc_info))
+
+
+def test_feature_union_concat_all_empty():
+    tr_Xs = [None, None]
+    n_samples_name = 4
+    w = [None, None]
+    scheduler = _normalize_scheduler(None, 1)
+    concat_name = 'testing'
+    dsk = {}
+    dsk[concat_name] = (feature_union_concat, tr_Xs, n_samples_name, w)
+    val = scheduler(dsk, concat_name)
+    assert len(val) == 4  # ! not 0
+    assert isinstance(val, np.ndarray)

--- a/examples/async_randomsearchcv.py
+++ b/examples/async_randomsearchcv.py
@@ -1,0 +1,137 @@
+import logging
+import numbers
+import dask_searchcv.online_model_selection as oms
+import numpy as np
+import toolz as tz
+from dask_searchcv import RandomizedSearchCV
+from distributed import Client, as_completed
+from sklearn.datasets import load_digits
+from sklearn.metrics.scorer import check_scoring
+from sklearn.svm import SVC
+from scipy import stats
+
+logger = logging.getLogger(__name__)
+
+
+def fit_async(
+    search, params_iter, criterion, X, y=None, groups=None, client=None, **fit_params
+):
+    if client is None:
+        client = Client()
+
+    estimator = search.estimator
+    search.scorer_ = check_scoring(estimator, scoring=search.scoring)
+    error_score = search.error_score
+    if not (isinstance(error_score, numbers.Number) or
+                    error_score == 'raise'):
+        raise ValueError("error_score must be the string 'raise' or a"
+                         " numeric value.")
+
+    dsk, X_name, y_name, cv_name, n_splits = oms.build_graph(
+        estimator, X, y, search.cv, groups, search.cache_cv)
+
+    search.dask_graph_ = dsk
+    search.n_splits_ = n_splits
+
+    ncores = len(client.ncores())
+
+    futures = []
+    job_map = {}
+
+    best_score, best_params = -np.inf, {}
+
+    for _ in range(ncores * 2):
+        params = next(params_iter)
+        cv_score_names = oms.update_graph(dsk, estimator, X_name, y_name, params, fit_params,
+                                          cv_name, n_splits,
+                                          search.scorer_, search.return_train_score,
+                                          error_score=error_score)
+
+        fs = client._graph_to_futures(dsk, cv_score_names)
+        score_name = 'score_{}'.format(oms.tokenize(params))
+        dsk[score_name] = (list, cv_score_names)
+        _, f = client._graph_to_futures(dsk, [score_name]).popitem()
+
+        futures.append(f)
+        job_map[f] = params
+
+    results = {}
+    af = as_completed(futures)
+    for future in af:
+        scores, params = future.result(), job_map[future]
+        test_score = np.mean(list(tz.pluck(0, scores))) if search.return_train_score else np.mean(
+            scores)
+        results[future] = test_score
+
+        if test_score > best_score:
+            best_score = test_score
+            best_params = params
+            logger.info('Best score now: {}, for parameters {}'.format(best_score, best_params))
+            if best_score > threshold:
+                break
+
+                #     if criterion(results):
+                #         break
+        params = next(params_iter)
+        cv_score_names = oms.update_graph(dsk, estimator, X_name, y_name, params, fit_params,
+                                          cv_name, n_splits,
+                                          search.scorer_, search.return_train_score,
+                                          error_score=error_score)
+
+        fs = client._graph_to_futures(dsk, cv_score_names)
+        score_name = 'score_{}'.format(oms.tokenize(params))
+        dsk[score_name] = (list, cv_score_names)
+        _, f = client._graph_to_futures(dsk, [score_name]).popitem()
+        af.add(f)
+        job_map[f] = params
+
+    client.shutdown()
+
+    return best_score, best_params
+
+
+@tz.curry
+def simple_criterion(threshold, results):
+    return max(results.values()) > threshold
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    digits = load_digits()
+
+    model = SVC(kernel='rbf')
+
+    n_splits = 3
+    param_space = {'C': np.linspace(0.00001, 1),
+                   'gamma': stats.expon(0.00001, 1),
+                   'class_weight': [None, 'balanced']}
+    n_splits = 3
+    n_iter = 100000
+    random_state = 1
+
+    search = RandomizedSearchCV(
+        estimator=model,
+        param_distributions=param_space,
+        cv=n_splits,
+        n_iter=n_iter,
+        random_state=random_state
+    )
+    X = digits.data
+    y = digits.target
+    groups = None
+    client = None
+    fit_params = {}
+    threshold = 0.9
+    params_iter = iter(search._get_param_iterator())
+    best_score = -np.inf
+
+    client = Client()
+    best_score, best_params = fit_async(
+        search, params_iter, None, digits.data, digits.target, client=client
+    )
+
+    logger.info("Search finished")
+    logger.info("best_score {}; best_params - {}".format(best_score, best_params))
+
+


### PR DESCRIPTION
This is an attempt at issue #32.

The following WIP:
- removes TokenIterator and main_token which are dependent on parameters and their ordering
- constructs tokens for the fit names based on parameters uniquely without depending on a mapping; the dask graph is queried directly for previously encountered tasks

The current approach in part evolved out of becoming familiar with the assumptions of the existing codebase so I ended up being strict about keys and defensive in graph updates (see `update_dsk`). Passing around and managing a global `seen` mapping with `dsk` may achieve the same effect with minimal code change.