### PR TITLE
A few tweaks

### DIFF
--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -396,6 +396,7 @@ def check_scores_all_nan(gs, bad_param):
                FailingClassifier.FAILING_PARAMETER)
 
 
+@ignore_warnings
 @pytest.mark.parametrize('weights',
         [None, (None, {'tr0': 2, 'tr2': 3}, {'tr0': 2, 'tr2': 4})])
 def test_feature_union(weights):

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -603,12 +603,13 @@ def test_scheduler_param(scheduler, n_jobs, get):
 @pytest.mark.skipif('not has_distributed')
 def test_scheduler_param_distributed(loop):
     X, y = make_classification(n_samples=100, n_features=10, random_state=0)
-    gs = dcv.GridSearchCV(MockClassifier(), {'foo_param': [0, 1, 2]}, cv=3)
     with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop):
+        with Client(s['address'], loop=loop, set_as_default=False) as client:
+            gs = dcv.GridSearchCV(MockClassifier(), {'foo_param': [0, 1, 2]},
+                                  cv=3, scheduler=client)
             gs.fit(X, y)
 
 
-def test_scheduler_param_bad(loop):
+def test_scheduler_param_bad():
     with pytest.raises(ValueError):
-        _normalize_scheduler('threeding', 4, loop)
+        _normalize_scheduler('threeding', 4)

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import pickle
+import warnings
 from itertools import product
 from multiprocessing import cpu_count
 
@@ -396,7 +397,6 @@ def check_scores_all_nan(gs, bad_param):
                FailingClassifier.FAILING_PARAMETER)
 
 
-@ignore_warnings
 @pytest.mark.parametrize('weights',
         [None, (None, {'tr0': 2, 'tr2': 3}, {'tr0': 2, 'tr2': 4})])
 def test_feature_union(weights):
@@ -435,7 +435,9 @@ def test_feature_union(weights):
 
     pipe = Pipeline([('union', union), ('est', CheckXClassifier())])
     gs = dcv.GridSearchCV(pipe, grid, refit=False, cv=2)
-    gs.fit(X, y)
+
+    with warnings.catch_warnings(record=True):
+        gs.fit(X, y)
 
 
 @ignore_warnings

--- a/dask_searchcv/utils_test.py
+++ b/dask_searchcv/utils_test.py
@@ -1,5 +1,7 @@
 import warnings
 
+from functools import wraps
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.validation import _num_samples, check_array
@@ -93,6 +95,7 @@ class FailingClassifier(BaseEstimator):
 
 def ignore_warnings(f):
     """A super simple version of `sklearn.utils.testing.ignore_warnings"""
+    @wraps(f)
     def _(*args, **kwargs):
         with warnings.catch_warnings(record=True):
             f(*args, **kwargs)


### PR DESCRIPTION
-  No longer accept address for `scheduler` kwarg

    This was causing things to lockup if an invalid parameter was passed in.
We now accept a `Client` instead, which is both simpler and more robust.

- Ignore warnings in `test_feature_union`

    Warnings are now visible due to recent `py.test` release. We can't turn this warning off easily, just ignore it.