### PR TITLE
Remove deprecated `sklearn.utils.fixes.rankdata`

### DIFF
--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -9,12 +9,12 @@ from distutils.version import LooseVersion
 import numpy as np
 from toolz import pluck
 from scipy import sparse
+from scipy.stats import rankdata
 from dask.base import normalize_token
 
 from sklearn.exceptions import FitFailedWarning
 from sklearn.pipeline import Pipeline, FeatureUnion
 from sklearn.utils import safe_indexing
-from sklearn.utils.fixes import rankdata
 from sklearn.utils.validation import check_consistent_length, _is_arraylike
 
 from .utils import copy_estimator


### PR DESCRIPTION
In `sklearn==0.19.0` this no longer exists; the docs say to use `scipy.stats.rankdata` instead which seems like it should work fine here.