### PR TITLE
ENH: Support multiple metrics

### DIFF
--- a/dask_searchcv/_compat.py
+++ b/dask_searchcv/_compat.py
@@ -1,0 +1,6 @@
+from distutils.version import LooseVersion
+from sklearn import __version__
+
+_SK_VERSION = LooseVersion(__version__)
+
+_HAS_MULTIPLE_METRICS = _SK_VERSION >= '0.19.0'

--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -319,11 +319,11 @@ def create_cv_results(scores, candidate_params, n_splits, error_score, weights,
             train_scores = [error_score if s is FIT_FAILURE else s
                             for s in train_scores]
     else:
-        test_scores = {k: [error_score if x[k] is FIT_FAILURE else x[k]
+        test_scores = {k: [error_score if x is FIT_FAILURE else x[k]
                            for x in test_scores]
                        for k in multimetric}
         if train_scores is not None:
-            train_scores = {k: [error_score if x[k] is FIT_FAILURE else x[k]
+            train_scores = {k: [error_score if x is FIT_FAILURE else x[k]
                                 for x in train_scores]
                             for k in multimetric}
 

--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -252,6 +252,9 @@ def fit_transform(est, X, y, error_score='raise', fields=None, params=None,
 def _score(est, X, y, scorer):
     if est is FIT_FAILURE:
         return FIT_FAILURE
+    if isinstance(scorer, dict):
+        return {k: v(est, X) if y is None else v(est, X, y)
+                for k, v in scorer.items()}
     return scorer(est, X) if y is None else scorer(est, X, y)
 
 
@@ -301,17 +304,23 @@ def _store(results, key_name, array, n_splits, n_candidates,
             rankdata(-array_means, method='min'), dtype=np.int32)
 
 
-def create_cv_results(scores, candidate_params, n_splits, error_score, weights):
+def create_cv_results(scores, candidate_params, n_splits, error_score, weights,
+                      multimetric):
     if len(scores[0]) == 4:
         fit_times, test_scores, score_times, train_scores = zip(*scores)
     else:
         fit_times, test_scores, score_times = zip(*scores)
         train_scores = None
 
-    test_scores = [error_score if s is FIT_FAILURE else s for s in test_scores]
-    if train_scores is not None:
-        train_scores = [error_score if s is FIT_FAILURE else s
-                        for s in train_scores]
+    if not multimetric:
+        test_scores = [error_score if s is FIT_FAILURE else s
+                       for s in test_scores]
+        if train_scores is not None:
+            train_scores = [error_score if s is FIT_FAILURE else s
+                            for s in train_scores]
+    else:
+        test_scores = {k: [x[k] for x in test_scores] for k in multimetric}
+        train_scores = {k: [x[k] for x in train_scores] for k in multimetric}
 
     # Construct the `cv_results_` dictionary
     results = {'params': candidate_params}
@@ -321,13 +330,23 @@ def create_cv_results(scores, candidate_params, n_splits, error_score, weights):
         weights = np.broadcast_to(weights[None, :],
                                   (len(candidate_params), len(weights)))
 
-    _store(results, 'test_score', test_scores, n_splits, n_candidates,
-           splits=True, rank=True, weights=weights)
     _store(results, 'fit_time', fit_times, n_splits, n_candidates)
     _store(results, 'score_time', score_times, n_splits, n_candidates)
-    if train_scores is not None:
-        _store(results, 'train_score', train_scores,
-               n_splits, n_candidates, splits=True)
+
+    if not multimetric:
+        _store(results, 'test_score', test_scores, n_splits, n_candidates,
+            splits=True, rank=True, weights=weights)
+        if train_scores is not None:
+            _store(results, 'train_score', train_scores,
+                n_splits, n_candidates, splits=True)
+    else:
+        for key in multimetric:
+            _store(results, 'test_{}'.format(key), test_scores[key], n_splits,
+                   n_candidates, splits=True, rank=True, weights=weights)
+        for key in multimetric:
+            if train_scores is not None:
+                _store(results, 'train_{}'.format(key), train_scores[key], n_splits,
+                    n_candidates, splits=True)
 
     # Use one MaskedArray and mask all the places where the param is not
     # applicable for that candidate. Use defaultdict as each candidate may
@@ -343,8 +362,11 @@ def create_cv_results(scores, candidate_params, n_splits, error_score, weights):
     return results
 
 
-def get_best_params(candidate_params, cv_results):
-    best_index = np.flatnonzero(cv_results["rank_test_score"] == 1)[0]
+def get_best_params(candidate_params, cv_results, scorer):
+    if scorer is True:
+        scorer = 'score'
+    best_index = np.flatnonzero(
+        cv_results["rank_test_{}".format(scorer)] == 1)[0]
     return candidate_params[best_index]
 
 

--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -348,10 +348,10 @@ def create_cv_results(scores, candidate_params, n_splits, error_score, weights,
         for key in multimetric:
             _store(results, 'test_{}'.format(key), test_scores[key], n_splits,
                    n_candidates, splits=True, rank=True, weights=weights)
-        for key in multimetric:
-            if train_scores is not None:
+        if train_scores is not None:
+            for key in multimetric:
                 _store(results, 'train_{}'.format(key), train_scores[key], n_splits,
-                    n_candidates, splits=True)
+                       n_candidates, splits=True)
 
     # Use one MaskedArray and mask all the places where the param is not
     # applicable for that candidate. Use defaultdict as each candidate may

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -820,14 +820,14 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         out = scheduler(dsk, keys, num_workers=n_jobs)
 
         self.cv_results_ = results = out[0]
-        if self.multimetric_:
-            score_key = self.refit
-        else:
-            score_key = 'score'
-        self.best_index_ = np.flatnonzero(
-            results["rank_test_{}".format(score_key)] == 1)[0]
-
         if self.refit:
+            if self.multimetric_:
+                score_key = self.refit
+            else:
+                score_key = 'score'
+            self.best_index_ = np.flatnonzero(
+                results["rank_test_{}".format(score_key)] == 1)[0]
+
             self.best_estimator_ = out[1]
         return self
 

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -691,6 +691,11 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         self.n_jobs = n_jobs
         self.cache_cv = cache_cv
 
+    def _check_if_refit(self, attr):
+        if not self.refit:
+            raise AttributeError(
+                "'{}' is not a valid attribute with 'refit=False'.".format(attr))
+
     @property
     def _estimator_type(self):
         return self.estimator._estimator_type
@@ -698,7 +703,8 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
     @property
     def best_params_(self):
         check_is_fitted(self, 'cv_results_')
-        if _HAS_MULTIPLE_METRICS and self.multimetric_:
+        self._check_if_refit('best_params_')
+        if _HAS_MULTIPLE_METRICS and self.multimetric_ and not self.refit:
             return {
                 k: self.cv_results_['params'][self.best_index_[k]]
                 for k in self.scorer_
@@ -708,6 +714,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
     @property
     def best_score_(self):
         check_is_fitted(self, 'cv_results_')
+        self._check_if_refit('best_score_')
         if _HAS_MULTIPLE_METRICS and self.multimetric_:
             return {
                 k: (self.cv_results_['mean_test_{}'.format(k)]

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -892,11 +892,15 @@ estimator : estimator object.
 
 {parameters}
 
-scoring : string, callable or None, default=None
+scoring : string, callable, dict of those, or None, default=None
     A string (see model evaluation documentation) or
     a scorer callable object / function with signature
     ``scorer(estimator, X, y)``.
+
     If ``None``, the ``score`` method of the estimator is used.
+
+    A dictionary of ``{scorer_name: string or callable}`` may be
+    used to evaluate with multiple metrics.
 
 iid : boolean, default=True
     If True, the data is assumed to be identically distributed across
@@ -915,10 +919,13 @@ cv : int, cross-validation generator or an iterable, optional
     either binary or multiclass, ``StratifiedKFold`` is used. In all
     other cases, ``KFold`` is used.
 
-refit : boolean, default=True
+refit : boolean or str, default=True
     Refit the best estimator with the entire dataset.
     If "False", it is impossible to make predictions using
     this {name} instance after fitting.
+
+    When using multiple metrics, this can be the name of the scorer to
+    use for selecting the best estimator.
 
 error_score : 'raise' (default) or numeric
     Value to assign to the score if an error occurs in estimator fitting.
@@ -1012,13 +1019,16 @@ best_estimator_ : estimator
     which gave highest score (or smallest loss if specified)
     on the left out data. Not available if refit=False.
 
-best_score_ : float
+best_score_ : float or dict of floats
     Score of best_estimator on the left out data.
+    When using multiple metrics, ``best_score_`` will be a dictionary
+    where the keys are the names of the scorers, and the values are
+    the mean test score for that scorer.
 
 best_params_ : dict
     Parameter setting that gave the best results on the hold out data.
 
-best_index_ : int
+best_index_ : int or dict of ints
     The index (of the ``cv_results_`` arrays) which corresponds to the best
     candidate parameter setting.
 
@@ -1026,9 +1036,14 @@ best_index_ : int
     the parameter setting for the best model, that gives the highest
     mean score (``search.best_score_``).
 
-scorer_ : function
+    When using multiple metrics, ``best_index_`` will be a dictionary
+    where the keys are the names of the scorers, and the values are
+    the index with the best mean score for that scorer, as described above.
+
+scorer_ : function or dict of functions
     Scorer function used on the held out data to choose the best
-    parameters for the model.
+    parameters for the model. A dictionary of ``{scorer_name: scorer}``
+    when multiple metrics are used.
 
 n_splits_ : int
     The number of cross-validation splits (folds/iterations).

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -792,7 +792,6 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
             Parameters passed to the ``fit`` method of the estimator
         """
         estimator = self.estimator
-        # self.scorer_ = check_scoring(estimator, scoring=self.scoring)
         if _HAS_MULTIPLE_METRICS:
             from sklearn.metrics.scorer import _check_multimetric_scoring
             scorer, multimetric = _check_multimetric_scoring(estimator,

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -801,7 +801,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
             self.multimetric_ = multimetric
 
         else:
-            self.scorer_ = check_scoring(estimator, scoring=self.scoring)
+            scorer = check_scoring(estimator, scoring=self.scoring)
             multimetric = False
 
         self.scorer_ = scorer

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -830,7 +830,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         out = scheduler(dsk, keys, num_workers=n_jobs)
 
         self.cv_results_ = results = out[0]
-        if self.multimetric_:
+        if _HAS_MULTIPLE_METRICS and self.multimetric_:
             if self.refit:
                 self.best_index_ = np.flatnonzero(
                     results["rank_test_{}".format(self.refit)] == 1)[0]

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -898,15 +898,20 @@ estimator : estimator object.
 
 {parameters}
 
-scoring : string, callable, dict of those, or None, default=None
-    A string (see model evaluation documentation) or
-    a scorer callable object / function with signature
-    ``scorer(estimator, X, y)``.
+scoring : string, callable, list/tuple, dict or None, default: None
+    A single string (see :ref:`scoring_parameter`) or a callable
+    (see :ref:`scoring`) to evaluate the predictions on the test set.
 
-    If ``None``, the ``score`` method of the estimator is used.
+    For evaluating multiple metrics, either give a list of (unique) strings
+    or a dict with names as keys and callables as values.
 
-    A dictionary of ``{{scorer_name: string or callable}}`` may be
-    used to evaluate with multiple metrics.
+    NOTE that when using custom scorers, each scorer should return a single
+    value. Metric functions returning a list/array of values can be wrapped
+    into multiple scorers that return one value each.
+
+    See :ref:`multimetric_grid_search` for an example.
+
+    If None, the estimator's default scorer (if available) is used.
 
 iid : boolean, default=True
     If True, the data is assumed to be identically distributed across
@@ -925,13 +930,25 @@ cv : int, cross-validation generator or an iterable, optional
     either binary or multiclass, ``StratifiedKFold`` is used. In all
     other cases, ``KFold`` is used.
 
-refit : boolean or str, default=True
-    Refit the best estimator with the entire dataset.
-    If "False", it is impossible to make predictions using
-    this {name} instance after fitting.
+refit : boolean, or string, default=True
+    Refit an estimator using the best found parameters on the whole
+    dataset.
 
-    When using multiple metrics, this can be the name of the scorer to
-    use for selecting the best estimator.
+    For multiple metric evaluation, this needs to be a string denoting the
+    scorer is used to find the best parameters for refitting the estimator
+    at the end.
+
+    The refitted estimator is made available at the ``best_estimator_``
+    attribute and permits using ``predict`` directly on this
+    ``GridSearchCV`` instance.
+
+    Also for multiple metric evaluation, the attributes ``best_index_``,
+    ``best_score_`` and ``best_parameters_`` will only be available if
+    ``refit`` is set and all of them will be determined w.r.t this specific
+    scorer.
+
+    See ``scoring`` parameter to know more about multiple metric
+    evaluation.
 
 error_score : 'raise' (default) or numeric
     Value to assign to the score if an error occurs in estimator fitting.

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -806,13 +806,13 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
                         # This will work for both dict / list (tuple)
                         self.refit not in scorer):
                     raise ValueError("For multi-metric scoring, the parameter "
-                                    "refit must be set to a scorer key "
-                                    "to refit an estimator with the best "
-                                    "parameter setting on the whole data and "
-                                    "make the best_* attributes "
-                                    "available for that metric. If this is not "
-                                    "needed, refit should be set to False "
-                                    "explicitly. %r was passed." % self.refit)
+                                     "refit must be set to a scorer key "
+                                     "to refit an estimator with the best "
+                                     "parameter setting on the whole data and "
+                                     "make the best_* attributes "
+                                     "available for that metric. If this is not "
+                                     "needed, refit should be set to False "
+                                     "explicitly. %r was passed." % self.refit)
         else:
             scorer = check_scoring(estimator, scoring=self.scoring)
             multimetric = False
@@ -899,8 +899,8 @@ estimator : estimator object.
 {parameters}
 
 scoring : string, callable, list/tuple, dict or None, default: None
-    A single string (see :ref:`scoring_parameter`) or a callable
-    (see :ref:`scoring`) to evaluate the predictions on the test set.
+    A single string or a callable to evaluate the predictions on the test
+    set.
 
     For evaluating multiple metrics, either give a list of (unique) strings
     or a dict with names as keys and callables as values.
@@ -908,8 +908,6 @@ scoring : string, callable, list/tuple, dict or None, default: None
     NOTE that when using custom scorers, each scorer should return a single
     value. Metric functions returning a list/array of values can be wrapped
     into multiple scorers that return one value each.
-
-    See :ref:`multimetric_grid_search` for an example.
 
     If None, the estimator's default scorer (if available) is used.
 

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -789,7 +789,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         # None indicates scikit-learn < 0.19 (when multimetric was added)
         # True indicates multiple metrics were used
         # False indicates a single metric was used
-        multimetric = getattr(self, 'multimetric_')
+        multimetric = getattr(self, 'multimetric_', None)
         if multimetric:
             multimetric = self.scorer_.keys()
         elif multimetric is False:

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -899,7 +899,7 @@ scoring : string, callable, dict of those, or None, default=None
 
     If ``None``, the ``score`` method of the estimator is used.
 
-    A dictionary of ``{scorer_name: string or callable}`` may be
+    A dictionary of ``{{scorer_name: string or callable}}`` may be
     used to evaluate with multiple metrics.
 
 iid : boolean, default=True
@@ -1042,7 +1042,7 @@ best_index_ : int or dict of ints
 
 scorer_ : function or dict of functions
     Scorer function used on the held out data to choose the best
-    parameters for the model. A dictionary of ``{scorer_name: scorer}``
+    parameters for the model. A dictionary of ``{{scorer_name: scorer}}``
     when multiple metrics are used.
 
 n_splits_ : int

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -46,6 +46,7 @@ from dask_searchcv.methods import CVCache
 from dask_searchcv.utils_test import (FailingClassifier, MockClassifier,
                                       ScalingTransformer, CheckXClassifier,
                                       ignore_warnings)
+from dask_searchcv._compat import _HAS_MULTIPLE_METRICS
 
 try:
     from distributed import Client
@@ -622,6 +623,7 @@ def test_scheduler_param_bad():
         _normalize_scheduler('threeding', 4)
 
 
+@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_multiple_metrics():
     from sklearn.metrics import make_scorer
     from sklearn.metrics import accuracy_score

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -22,7 +22,6 @@ from sklearn.datasets import make_classification, load_iris
 from sklearn.decomposition import PCA
 from sklearn.exceptions import NotFittedError, FitFailedWarning
 from sklearn.feature_selection import SelectKBest
-from sklearn.metrics import make_scorer, accuracy_score
 from sklearn.metrics.scorer import _passthrough_scorer
 from sklearn.model_selection import (KFold,
                                      GroupKFold,
@@ -44,6 +43,7 @@ from sklearn.svm import SVC
 import dask_searchcv as dcv
 from dask_searchcv.model_selection import (compute_n_splits, check_cv,
         _normalize_n_jobs, _normalize_scheduler)
+from dask_searchcv._compat import _HAS_MULTIPLE_METRICS
 from dask_searchcv.methods import CVCache
 from dask_searchcv.utils_test import (FailingClassifier, MockClassifier,
                                       ScalingTransformer, CheckXClassifier,
@@ -451,7 +451,9 @@ def test_feature_union(weights):
 @ignore_warnings
 @pytest.mark.parametrize("scoring", [
     None,
-    {"score_1": _passthrough_scorer, "score_2": _passthrough_scorer}
+    pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")(
+        {"score_1": _passthrough_scorer, "score_2": _passthrough_scorer}
+    )
 ])
 def test_feature_union_fit_failure(scoring):
     X, y = make_classification(n_samples=100, n_features=10, random_state=0)

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -237,9 +237,10 @@ def test_no_refit():
     clf = MockClassifier()
     grid_search = dcv.GridSearchCV(clf, {'foo_param': [1, 2, 3]}, refit=False)
     grid_search.fit(X, y)
-    assert (not hasattr(grid_search, "best_estimator_") and
-                hasattr(grid_search, "best_index_") and
-                hasattr(grid_search, "best_params_"))
+    assert not hasattr(grid_search, "best_estimator_")
+    assert not hasattr(grid_search, "best_index_")
+    assert not hasattr(grid_search, "best_score_")
+    assert not hasattr(grid_search, "best_params_")
 
     # Make sure the predict/transform etc fns raise meaningfull error msg
     for fn_name in ('predict', 'predict_proba', 'predict_log_proba',
@@ -258,9 +259,10 @@ def test_no_refit_multiple_metrics():
     gs = dcv.GridSearchCV(clf, {'max_depth': [1, 2, 3]}, refit=False,
                           scoring=scoring)
     gs.fit(da_X, da_y)
-    assert (not hasattr(gs, "best_estimator_") and
-                hasattr(gs, "best_index_") and
-                hasattr(gs, "best_params_"))
+    assert not hasattr(gs, "best_estimator_")
+    assert not hasattr(gs, "best_index_")
+    assert not hasattr(gs, "best_score_")
+    assert not hasattr(gs, "best_params_")
 
     for fn_name in ('predict', 'predict_proba', 'predict_log_proba'):
         with pytest.raises(NotFittedError) as exc:

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -962,8 +962,7 @@ def test_search_train_scores_set_to_false():
 
 @pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_multiple_metrics():
-    from sklearn.metrics import make_scorer
-    from sklearn.metrics import accuracy_score
+    from sklearn.metrics import make_scorer, accuracy_score
     from sklearn.tree import DecisionTreeClassifier
 
     scoring = {'AUC': 'roc_auc', 'Accuracy': make_scorer(accuracy_score)}
@@ -975,7 +974,7 @@ def test_multiple_metrics():
     # ``gs.best_index_``
     gs = dcv.GridSearchCV(DecisionTreeClassifier(random_state=42),
                           param_grid={'min_samples_split': range(2, 403, 10)},
-                          scoring=scoring, cv=5, refit='AUC')
+                          scoring=scoring, cv=5, refit=False)
     gs.fit(da_X, da_y)
     # some basic checks
     assert set(gs.scorer_) == {'AUC', 'Accuracy'}

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -250,6 +250,7 @@ def test_no_refit():
                  'best parameters' % fn_name) in str(exc.value))
 
 
+@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_no_refit_multiple_metrics():
     clf = DecisionTreeClassifier()
     scoring = {'score_1': 'accuracy', 'score_2': 'accuracy'}

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -993,7 +993,7 @@ def test_multiple_metrics():
     # ``gs.best_index_``
     gs = dcv.GridSearchCV(DecisionTreeClassifier(random_state=42),
                           param_grid={'min_samples_split': range(2, 403, 10)},
-                          scoring=scoring, cv=5, refit=False)
+                          scoring=scoring, cv=5, refit='AUC')
     gs.fit(da_X, da_y)
     # some basic checks
     assert set(gs.scorer_) == {'AUC', 'Accuracy'}

--- a/dask_searchcv/tests/test_model_selection_sklearn.py
+++ b/dask_searchcv/tests/test_model_selection_sklearn.py
@@ -236,7 +236,7 @@ def test_no_refit():
     # Test that GSCV can be used for model selection alone without refitting
     clf = MockClassifier()
     grid_search = dcv.GridSearchCV(clf, {'foo_param': [1, 2, 3]}, refit=False)
-    grid_search.fit(da_X, da_y)
+    grid_search.fit(X, y)
     assert (not hasattr(grid_search, "best_estimator_") and
                 hasattr(grid_search, "best_index_") and
                 hasattr(grid_search, "best_params_"))


### PR DESCRIPTION
Closes https://github.com/dask/dask-searchcv/issues/52

```python
In [1]: from sklearn.datasets import make_hastie_10_2
   ...: from sklearn.metrics import make_scorer
   ...: from sklearn.metrics import accuracy_score
   ...: from sklearn.tree import DecisionTreeClassifier
   ...:
   ...: import dask_searchcv as dcv
   ...:
   ...: X, y = make_hastie_10_2(n_samples=1000, random_state=42)
   ...:
   ...: # The scorers can be either be one of the predefined metric strings or a scorer
   ...: # callable, like the one returned by make_scorer
   ...: scoring = {'AUC': 'roc_auc', 'Accuracy': make_scorer(accuracy_score)}
   ...:
   ...: # Setting refit='AUC', refits an estimator on the whole dataset with the
   ...: # parameter setting that has the best cross-validated AUC score.
   ...: # That estimator is made available at ``gs.best_estimator_`` along with
   ...: # parameters like ``gs.best_score_``, ``gs.best_parameters_`` and
   ...: # ``gs.best_index_``
   ...: a = dcv.GridSearchCV(DecisionTreeClassifier(random_state=42),
   ...:                      param_grid={'min_samples_split': range(2, 403, 10)},
   ...:                      scoring=scoring, cv=5, refit='AUC')
   ...: a.fit(X, y)
   ...:

In [2]: a.scorer_
Out[2]:
{'AUC': make_scorer(roc_auc_score, needs_threshold=True),
 'Accuracy': make_scorer(accuracy_score)}

In [3]: a.multimetric_
Out[3]: True

In [4]: a.cv_results_.keys()
Out[4]: dict_keys(['params', 'mean_fit_time', 'std_fit_time', 'mean_score_time',
... 'std_score_time', 'split0_test_AUC', 'split1_test_AUC', 'split2_test_AUC',
... 'split3_test_AUC', 'split4_test_AUC', 'mean_test_AUC', 'std_test_AUC',
... 'rank_test_AUC', 'split0_test_Accuracy', 'split1_test_Accuracy',
... 'split2_test_Accuracy', 'split3_test_Accuracy', 'split4_test_Accuracy',
... 'mean_test_Accuracy', 'std_test_Accuracy', 'rank_test_Accuracy',
... 'split0_train_AUC', 'split1_train_AUC', 'split2_train_AUC',
... 'split3_train_AUC', 'split4_train_AUC', 'mean_train_AUC',
... 'std_train_AUC', 'split0_train_Accuracy', 'split1_train_Accuracy',
... 'split2_train_Accuracy', 'split3_train_Accuracy', 'split4_train_Accuracy',
... 'mean_train_Accuracy', 'std_train_Accuracy', 'param_min_samples_split'])
```

I'll add more tests later, but does the overall approach look OK here @jcrist? I had to modify a few places, but none of the modifications were that extensive.

cc @jnothman