### PR TITLE
Fix dask.base.Base usage to dask.base.is_dask_collection

### DIFF
--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -15,9 +15,12 @@ from dask.base import normalize_token
 from sklearn.exceptions import FitFailedWarning
 from sklearn.pipeline import Pipeline, FeatureUnion
 from sklearn.utils import safe_indexing
-from sklearn.utils.validation import check_consistent_length, _is_arraylike
+from sklearn.utils.validation import (check_consistent_length as _check_consistent_length,
+                                      _is_arraylike)
 
 from .utils import copy_estimator
+
+
 
 # Copied from scikit-learn/sklearn/utils/fixes.py, can be removed once we drop
 # support for scikit-learn < 0.18.1 or numpy < 1.12.0.
@@ -64,6 +67,17 @@ def warn_fit_failure(error_score, e):
 # ----------------------- #
 
 
+
+def check_consistent_length(*arrays):
+    try:
+        from elm.mldataset import is_mldataset
+    except:
+        is_mldataset = lambda x: False
+    if any(is_mldataset(arr) for arr in arrays):
+        return True # TODO ? consequence?
+    return _check_consistent_length(*arrays)
+
+
 class CVCache(object):
     def __init__(self, splits, pairwise=False, cache=True):
         self.splits = splits
@@ -101,7 +115,11 @@ class CVCache(object):
             return self.cache[n, is_x, is_train]
 
         inds = self.splits[n][0] if is_train else self.splits[n][1]
-        result = safe_indexing(X if is_x else y, inds)
+        post_splits = getattr(self, '_post_splits', None)
+        if post_splits:
+            result = post_splits(inds)
+        else:
+            result = safe_indexing(X if is_x else y, inds)
 
         if self.cache is not None:
             self.cache[n, is_x, is_train] = result
@@ -117,16 +135,33 @@ class CVCache(object):
         if X.shape[0] != X.shape[1]:
             raise ValueError("X should be a square kernel matrix")
         train, test = self.splits[n]
+        post_splits = getattr(self, '_post_splits', None)
         result = X[np.ix_(train if is_train else test, train)]
-
+        if post_splits:
+            result = post_splits(result)
         if self.cache is not None:
             self.cache[n, True, is_train] = result
         return result
 
 
-def cv_split(cv, X, y, groups, is_pairwise, cache):
-    check_consistent_length(X, y, groups)
-    return CVCache(list(cv.split(X, y, groups)), is_pairwise, cache)
+def cv_split(cv, X, y, groups, is_pairwise, cache, sampler):
+    print('cv, X, y, groups, is_pairwise, cache, sampler', cv, X, y, groups, is_pairwise, cache, sampler)
+    kw = dict(pairwise=is_pairwise, cache=cache)
+    if sampler is None:
+        _check_consistent_length(X, y, groups)
+    if cache and not hasattr(cache, 'extract'):
+        cls = CVCache
+        kw.pop('sampler')
+    else:
+        cls = cache
+        kw['cache'] = True
+    splits = list(cv.split(X, y, groups))
+    print('cls', cls, splits, kw)
+    if sampler:
+        args = (sampler, splits,)
+    else:
+        args = (splits,)
+    return cls(*args, **kw)
 
 
 def cv_n_samples(cvs):
@@ -200,11 +235,13 @@ def set_params(est, fields=None, params=None, copy=True):
     # TODO: rewrite set_params to avoid lock for classes that use the standard
     # set_params/get_params methods
     with SET_PARAMS_LOCK:
+        #print('params sp', fields, est, params)
         return est.set_params(**params)
 
 
 def fit(est, X, y, error_score='raise', fields=None, params=None,
         fit_params=None):
+    #print('estxxxx', est, X, y, fields, params, fit_params)
     if X is FIT_FAILURE:
         est, fit_time = FIT_FAILURE, 0.0
     else:
@@ -226,6 +263,7 @@ def fit(est, X, y, error_score='raise', fields=None, params=None,
 
 def fit_transform(est, X, y, error_score='raise', fields=None, params=None,
                   fit_params=None):
+    #print('estftxxx', est, fields, params, fit_params)
     if X is FIT_FAILURE:
         est, fit_time, Xt = FIT_FAILURE, 0.0, FIT_FAILURE
     else:
@@ -302,6 +340,7 @@ def _store(results, key_name, array, n_splits, n_candidates,
 
 
 def create_cv_results(scores, candidate_params, n_splits, error_score, weights):
+    print('scores, candidate_params, n_splits, error_score, weights', scores, candidate_params, n_splits, error_score, weights)
     if len(scores[0]) == 4:
         fit_times, test_scores, score_times, train_scores = zip(*scores)
     else:

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -72,6 +72,7 @@ def build_graph(estimator, cv, scorer, candidate_params, X, y=None,
     is_pairwise = getattr(estimator, '_pairwise', False)
     X_name, y_name, groups_name = to_keys(dsk, X, y, groups)
     n_splits = compute_n_splits(cv, X, y, groups)
+    print('X_name, y_name, n_splits, is_pairwise, X, y, groups', X_name, y_name, n_splits, is_pairwise, X, y, groups)
     if fit_params:
         # A mapping of {name: (name, graph-key)}
         param_values = to_indexable(*fit_params.values(), allow_scalars=True)
@@ -79,7 +80,7 @@ def build_graph(estimator, cv, scorer, candidate_params, X, y=None,
                       zip(fit_params, to_keys(dsk, *param_values))}
     else:
         fit_params = {}
-
+    print('fit_params', fit_params)
     fields, tokens, params = normalize_params(candidate_params)
     main_token = tokenize(normalize_estimator(estimator), fields, params,
                           X_name, y_name, groups_name, fit_params, cv,
@@ -118,7 +119,7 @@ def build_graph(estimator, cv, scorer, candidate_params, X, y=None,
         dsk[best_estimator] = (fit_best, clone(estimator), best_params,
                                X_name, y_name, fit_params)
         keys.append(best_estimator)
-
+    print('dsk,keys, n_splits', dsk,keys, n_splits)
     return dsk, keys, n_splits
 
 
@@ -232,8 +233,10 @@ def do_fit_and_score(dsk, main_token, est, cv, fields, tokens, params,
 
 def do_fit(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
            fit_params, n_splits, error_score):
+    print('do_fit', dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
+           fit_params, n_splits, error_score)
     if is_pipeline(est) and params is not None:
-        #print('pppp', params)
+        print('pppp', params)
         return _do_pipeline(dsk, next_token, est, cv, fields, tokens, params,
                             Xs, ys, fit_params, n_splits, error_score, False)
     else:
@@ -528,6 +531,7 @@ def _do_featureunion(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
                                     params, Xs, ys, fit_params, n_splits,
                                     error_score, step_fields_lk, fit_params_lk,
                                     field_to_index, step_name, False, True)
+        print('fitts outs', fits, out_Xs)
         fit_steps.append(fits)
         tr_Xs.append(out_Xs)
 
@@ -561,6 +565,7 @@ def _do_featureunion(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,
     seen = {}
     for steps, Xs, wt, (w, wl), nsamp in zip(zip(*fit_steps), zip(*tr_Xs),
                                              weight_tokens, weights, n_samples):
+        print('sX,w,wwl, nsamp', steps, Xs, wt, (w, wl), nsamp)
         if (steps, wt) in seen:
             out_append(seen[steps, wt])
         else:
@@ -810,7 +815,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
                                           cache_cv=self.cache_cv)
         self.dask_graph_ = dsk
         self.n_splits_ = n_splits
-
+        print('fit vars(self)', vars(self))
         n_jobs = _normalize_n_jobs(self.n_jobs)
         scheduler = _normalize_scheduler(self.scheduler, n_jobs)
 

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -8,7 +8,7 @@ import numbers
 
 import numpy as np
 import dask
-from dask.base import tokenize, Base
+from dask.base import tokenize, is_dask_collection
 from dask.delayed import delayed
 from dask.threaded import get as threaded_get
 from dask.utils import derived_from
@@ -558,7 +558,7 @@ def check_cv(cv=3, y=None, classifier=False):
 
     # If ``cv`` is not an integer, the scikit-learn implementation doesn't
     # touch the ``y`` object, so passing on a dask object is fine
-    if not isinstance(y, Base) or not isinstance(cv, numbers.Integral):
+    if not is_dask_collection(y) or not isinstance(cv, numbers.Integral):
         return model_selection.check_cv(cv, y, classifier)
 
     if classifier:
@@ -581,7 +581,7 @@ def compute_n_splits(cv, X, y=None, groups=None):
     -------
     n_splits : int
     """
-    if not any(isinstance(i, Base) for i in (X, y, groups)):
+    if not any(is_dask_collection(i) for i in (X, y, groups)):
         return cv.get_n_splits(X, y, groups)
 
     if isinstance(cv, (_BaseKFold, BaseShuffleSplit)):
@@ -593,12 +593,12 @@ def compute_n_splits(cv, X, y=None, groups=None):
     elif isinstance(cv, _CVIterableWrapper):
         return len(cv.cv)
 
-    elif isinstance(cv, (LeaveOneOut, LeavePOut)) and not isinstance(X, Base):
+    elif isinstance(cv, (LeaveOneOut, LeavePOut)) and not is_dask_collection(X):
         # Only `X` is referenced for these classes
         return cv.get_n_splits(X, None, None)
 
     elif (isinstance(cv, (LeaveOneGroupOut, LeavePGroupsOut)) and not
-          isinstance(groups, Base)):
+          is_dask_collection(groups)):
         # Only `groups` is referenced for these classes
         return cv.get_n_splits(None, None, groups)
 

--- a/dask_searchcv/utils.py
+++ b/dask_searchcv/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 
 import dask.array as da
@@ -5,6 +6,27 @@ from dask.base import Base, tokenize
 from dask.delayed import delayed, Delayed
 
 from sklearn.utils.validation import indexable, _is_arraylike
+from sklearn.pipeline import Pipeline as sk_Pipeline
+
+def is_pipeline(estimator):
+    print('is_pipeline', estimator)
+    if isinstance(estimator, sk_Pipeline):
+        ret = True
+    try:
+        from elm.pipeline import Pipeline as elm_Pipeline
+        ret = isinstance(estimator, elm_Pipeline)
+    except:
+        ret = False
+    print('is_pipeline', estimator, ret)
+    return ret
+
+def _get_est_type(est):
+    if hasattr(est, '_cls') and hasattr(est._cls, '__name__'):
+        est_type = est._cls.__name__.lower()
+    else:
+        est_type = type(est).__name__.lower()
+    print('_get_est_type', est_type)
+    return est_type
 
 
 def _indexable(x):

--- a/dask_searchcv/utils.py
+++ b/dask_searchcv/utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 
 import dask.array as da
-from dask.base import Base, tokenize
+from dask.base import is_dask_collection, tokenize
 from dask.delayed import delayed, Delayed
 
 from sklearn.utils.validation import indexable, _is_arraylike
@@ -52,7 +52,7 @@ def to_indexable(*args, **kwargs):
     for x in args:
         if x is None or isinstance(x, da.Array):
             yield x
-        elif isinstance(x, Base):
+        elif is_dask_collection(x):
             yield delayed(indexable, pure=True)(x)
         else:
             yield indexable(x)
@@ -70,7 +70,7 @@ def to_keys(dsk, *args):
             dsk.update(x.dask)
             yield x.key
         else:
-            assert not isinstance(x, Base)
+            assert not is_dask_collection(x)
             key = 'array-' + tokenize(x)
             dsk[key] = x
             yield key

--- a/dask_searchcv/utils.py
+++ b/dask_searchcv/utils.py
@@ -9,7 +9,6 @@ from sklearn.utils.validation import indexable, _is_arraylike
 from sklearn.pipeline import Pipeline as sk_Pipeline
 
 def is_pipeline(estimator):
-    print('is_pipeline', estimator)
     if isinstance(estimator, sk_Pipeline):
         ret = True
     try:
@@ -17,7 +16,6 @@ def is_pipeline(estimator):
         ret = isinstance(estimator, elm_Pipeline)
     except:
         ret = False
-    print('is_pipeline', estimator, ret)
     return ret
 
 def _get_est_type(est):

--- a/dask_searchcv/utils.py
+++ b/dask_searchcv/utils.py
@@ -19,11 +19,10 @@ def is_pipeline(estimator):
     return ret
 
 def _get_est_type(est):
-    if hasattr(est, '_cls') and hasattr(est._cls, '__name__'):
-        est_type = est._cls.__name__.lower()
+    if hasattr(est, '_cls_name'):
+        est_type = est._cls_name.lower()
     else:
         est_type = type(est).__name__.lower()
-    print('_get_est_type', est_type)
     return est_type
 
 


### PR DESCRIPTION
Fix use of `instance(X, dask.base.Base)`.  Replace with `dask.base.is_dask_collection(X)`.  This is a branch off of #61 (but I can change the base branch of this PR if needed).