### PR TITLE
Update dask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON=2.7 SKLEARN=0.18.1 TEST_FLAGS=
-    - PYTHON=3.5 SKLEARN=0.18.0 TEST_FLAGS=
-    - PYTHON=3.6 SKLEARN=0.19.0 TEST_FLAGS=--doctest-modules
+    - PYTHON=2.7 SKLEARN=0.18.1 DASK_DEV='false' TEST_FLAGS=
+    - PYTHON=3.5 SKLEARN=0.18.0 DASK_DEV='false' TEST_FLAGS=
+    - PYTHON=3.6 SKLEARN=0.19.0 DASK_DEV='true' TEST_FLAGS=--doctest-modules
 
 addons:
     apt:
@@ -24,6 +24,8 @@ install:
   - conda create -n test-environment python=$PYTHON
   - source activate test-environment
   - conda install dask distributed numpy scikit-learn=$SKLEARN cytoolz pytest
+  - if [[ $DASK_DEV == 'true' ]]; then pip install -U git+https://github.com/dask/dask.git; fi
+  - if [[ $DASK_DEV == 'true' ]]; then pip install -U git+https://github.com/dask/distributed.git; fi
   - pip install -q graphviz flake8
   - pip install --no-deps -e .
 

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -51,7 +51,7 @@ try:
     from distributed import Client
     from distributed.utils_test import cluster, loop
     has_distributed = True
-except:
+except ImportError:
     loop = pytest.fixture(lambda: None)
     has_distributed = False
 


### PR DESCRIPTION
- Use `is_dask_collection` everywhere if dask version supports it. Remain backwards compatible if not.
- Update travis to use dev versions in one build

Supersedes #62.