### PR TITLE
Allow CVCache subclasses

### DIFF
--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -125,7 +125,6 @@ class CVCache(object):
 
 
 def cv_split(cv, X, y, groups, is_pairwise, cache):
-
     if not cache or isinstance(cache, bool):
         check_consistent_length(X, y, groups)
         splits = list(cv.split(X, y, groups))
@@ -134,7 +133,11 @@ def cv_split(cv, X, y, groups, is_pairwise, cache):
     params = dict(pairwise=is_pairwise,
                   cache={},
                   splits=splits)
-    cache.set_params(**params)
+    if hasattr(cache, 'set_params'):
+        cache.set_params(**params)
+    else:
+        for k, v in params.items():
+            setattr(cache, k, v)
     return cache
 
 

--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -125,10 +125,12 @@ class CVCache(object):
 
 
 def cv_split(cv, X, y, groups, is_pairwise, cache):
-    splits = list(cv.split(X, y, groups))
+
     if not cache or isinstance(cache, bool):
         check_consistent_length(X, y, groups)
-        return CVCache(list(cv.split(X, y, groups)), is_pairwise, cache)
+        splits = list(cv.split(X, y, groups))
+        return CVCache(splits, is_pairwise, cache)
+    splits = list(cv.split(X, y, groups))
     params = dict(pairwise=is_pairwise,
                   cache={},
                   splits=splits)

--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -125,8 +125,15 @@ class CVCache(object):
 
 
 def cv_split(cv, X, y, groups, is_pairwise, cache):
-    check_consistent_length(X, y, groups)
-    return CVCache(list(cv.split(X, y, groups)), is_pairwise, cache)
+    splits = list(cv.split(X, y, groups))
+    if not cache or isinstance(cache, bool):
+        check_consistent_length(X, y, groups)
+        return CVCache(list(cv.split(X, y, groups)), is_pairwise, cache)
+    params = dict(pairwise=is_pairwise,
+                  cache={},
+                  splits=splits)
+    cache.set_params(**params)
+    return cache
 
 
 def cv_n_samples(cvs):

--- a/dask_searchcv/methods.py
+++ b/dask_searchcv/methods.py
@@ -125,20 +125,8 @@ class CVCache(object):
 
 
 def cv_split(cv, X, y, groups, is_pairwise, cache):
-    if not cache or isinstance(cache, bool):
-        check_consistent_length(X, y, groups)
-        splits = list(cv.split(X, y, groups))
-        return CVCache(splits, is_pairwise, cache)
-    splits = list(cv.split(X, y, groups))
-    params = dict(pairwise=is_pairwise,
-                  cache={},
-                  splits=splits)
-    if hasattr(cache, 'set_params'):
-        cache.set_params(**params)
-    else:
-        for k, v in params.items():
-            setattr(cache, k, v)
-    return cache
+    check_consistent_length(X, y, groups)
+    return CVCache(list(cv.split(X, y, groups)), is_pairwise, cache)
 
 
 def cv_n_samples(cvs):

--- a/dask_searchcv/model_selection.py
+++ b/dask_searchcv/model_selection.py
@@ -895,7 +895,6 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
 
         return self
 
-
     def visualize(self, filename='mydask', format=None, **kwargs):
         """Render the task graph for this parameter search using ``graphviz``.
 

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -721,16 +721,17 @@ def test_cv_cache_instance_to_search(cv_split, refit, should_pass):
                                  random_state=0)
         if refit == 'sample_x':
             estimator = MockUnsupervised()
-            refit = Xy[0]
+            Xy = Xy[0]
         else:
             estimator = MockClassifier()
-            refit = Xy
+        refit = True
+    else:
+        estimator = MockClassifier()
 
     class GridSearchCVSampler(dcv.GridSearchCV):
 
-        @classmethod
-        def _get_cv_split(self, *a, **kw):
-            return cv_split
+        def _get_cv_split_refit_Xy(self, *a, **kw):
+            return cv_split, Xy
 
     def fit_pred():
         gs = GridSearchCVSampler(estimator,

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -656,6 +656,7 @@ def test_scheduler_param_bad():
 
 class CacheCVLike(CVCache):
     called = 0
+
     def __init__(self, splits=None, pairwise=False, cache=True):
         CVCache.__init__(self, splits=splits, pairwise=pairwise, cache=cache)
 
@@ -710,7 +711,6 @@ def cv_split_bad(cv, X, y, groups, is_pairwise, cache):
     (cv_split_bad, 'sample_xy', False),
 ])
 def test_cv_cache_instance_to_search(cv_split, refit, should_pass):
-    called = 0
     n_splits = 3
     cv = KFold(n_splits)
     pg = {'foo_param': list(range(2, 100))}
@@ -726,7 +726,6 @@ def test_cv_cache_instance_to_search(cv_split, refit, should_pass):
             estimator = MockClassifier()
             refit = Xy
 
-
     class GridSearchCVSampler(dcv.GridSearchCV):
 
         @classmethod
@@ -735,9 +734,9 @@ def test_cv_cache_instance_to_search(cv_split, refit, should_pass):
 
     def fit_pred():
         gs = GridSearchCVSampler(estimator,
-                             pg,
-                             cv=cv,
-                             refit=refit)
+                                 pg,
+                                 cv=cv,
+                                 refit=refit)
 
         gs.fit(example_arguments)
         X, _ = make_classification(n_samples=100,
@@ -798,4 +797,3 @@ def test_cv_multiplemetrics_no_refit():
     assert hasattr(a, 'best_index_') is hasattr(b, 'best_index_')
     assert hasattr(a, 'best_estimator_') is hasattr(b, 'best_estimator_')
     assert hasattr(a, 'best_score_') is hasattr(b, 'best_score_')
-

--- a/dask_searchcv/tests/test_model_selection.py
+++ b/dask_searchcv/tests/test_model_selection.py
@@ -680,12 +680,14 @@ class BadCacheCV(CVCache):
 
 example_arguments = ['argument_{}'.format(_) for _ in range(15)]
 
+
 def cv_split_X_y_ok(cv, X, y, groups, is_pairwise, cache):
     for xi in X:
         # normally one would use elements of X to inform how
         # a sample should be drawn, e.g. filenames (see example_arguments above)
         assert hasattr(xi, 'startswith') and xi.startswith('argument_')
     return CacheCVLike(list(cv.split(X, y, groups)), is_pairwise, cache)
+
 
 def cv_split_X_ok(cv, X, y, groups, is_pairwise, cache):
     return CacheCVLike(list(cv.split(X, y, groups)), is_pairwise, cache)

--- a/dask_searchcv/utils.py
+++ b/dask_searchcv/utils.py
@@ -8,6 +8,7 @@ from dask.delayed import delayed, Delayed
 
 from sklearn.utils.validation import indexable, _is_arraylike
 
+from ._compat import _HAS_MULTIPLE_METRICS, _SK_VERSION
 
 if LooseVersion(dask.__version__) > '0.15.4':
     from dask.base import is_dask_collection

--- a/dask_searchcv/utils_test.py
+++ b/dask_searchcv/utils_test.py
@@ -178,9 +178,9 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
             score = 0.
         return score
 
+
 class MockUnsupervised(MockClassifier):
 
     def fit(self, X, y=None, **kw):
         assert getattr(X, 'ndim', None) == 2 and X.shape[0]
         return self
-

--- a/dask_searchcv/utils_test.py
+++ b/dask_searchcv/utils_test.py
@@ -177,3 +177,10 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
         else:
             score = 0.
         return score
+
+class MockUnsupervised(MockClassifier):
+
+    def fit(self, X, y=None, **kw):
+        assert getattr(X, 'ndim', None) == 2 and X.shape[0]
+        return self
+


### PR DESCRIPTION
This PR allows classes inheriting from `DaskBaseSearchCV` to pass a `CVCache`-like instance as the `cache_cv` keyword.  

This PR replaces #61 - responding to feedback there from @mrocklin / @TomAugspurger  on reducing impact to dask-searchcv associated with elm's wrapping of scikit-learn.  

I'll add a test for passing in a CVCache-like instance.
